### PR TITLE
Configure gitplag deployment

### DIFF
--- a/.github/workflows/release-deployment-workflow.yml
+++ b/.github/workflows/release-deployment-workflow.yml
@@ -58,7 +58,9 @@ jobs:
           username: ${{ secrets.DEV_USERNAME }}
           password: ${{ secrets.DEV_PASSWORD }}
           script: |
-            docker exec flaxo-db pg_dump -U ${{ secrets.POSTGRES_USER }} ${{ secrets.POSTGRES_DB }} > /root/flaxo-automation/dumps/flaxo.$(date +%Y-%m-%d.%H:%M:%S).bak
+            CURRENT_DATE=$(date +%Y-%m-%d.%H:%M:%S)
+            docker exec flaxo-db pg_dump -U ${{ secrets.POSTGRES_USER }} ${{ secrets.POSTGRES_DB }} > "/root/flaxo-automation/dumps/flaxo.$CURRENT_DATE.bak"
+            docker exec flaxo-db pg_dump -U ${{ secrets.POSTGRES_USER }} ${{ secrets.GITPLAG_POSTGRES_DB }} > "/root/flaxo-automation/dumps/gitplag.$CURRENT_DATE.bak"
   deploy:
     name: Deploy flaxo to dev server
     runs-on: ubuntu-latest

--- a/.github/workflows/release-deployment-workflow.yml
+++ b/.github/workflows/release-deployment-workflow.yml
@@ -71,14 +71,16 @@ jobs:
           REST_URL: http://${{ secrets.DEV_HOST }}:${{ secrets.DEV_PORT }}/rest
           GITHUB_ID: ${{ secrets.GITHUB_ID }}
           GITHUB_SECRET: ${{ secrets.GITHUB_SECRET }}
+          GITPLAG_GITHUB_AUTH: ${{ secrets.GITPLAG_GITHUB_AUTH }}
           MOSS_USER_ID: ${{ secrets.MOSS_USER_ID }}
           POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
           POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
-          DATA_DIR: /root/flaxo-automation/db
-          LOGS_DIR: /root/flaxo-automation/logs
+          GITPLAG_POSTGRES_DB: ${{ secrets.GITPLAG_POSTGRES_DB }}
           DATA2GRAPH_TAG: 0.4
           GITPLAG_TAG: 0.5.2
+          DATA_DIR: /root/flaxo-automation/db
+          LOGS_DIR: /root/flaxo-automation/logs
           GITPLAG_DIR: /root/flaxo-automation/gitplag
           DEPLOY_DIR: /root/flaxo-automation/deploy
         with:
@@ -86,28 +88,40 @@ jobs:
           port: ${{ secrets.DEV_PORT }}
           username: ${{ secrets.DEV_USERNAME }}
           password: ${{ secrets.DEV_PASSWORD }}
-          envs: REST_URL,GITHUB_ID,GITHUB_SECRET,MOSS_USER_ID,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,DATA_DIR,LOGS_DIR,DATA2GRAPH_TAG,GITPLAG_TAG,GITPLAG_DIR,DEPLOY_DIR,GITHUB_SHA,GITHUB_REF
+          envs: DEPLOYMENT_URL,REST_URL,GITHUB_ID,GITHUB_SECRET,GITPLAG_GITHUB_AUTH,MOSS_USER_ID,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,GITPLAG_POSTGRES_DB,DATA2GRAPH_TAG,GITPLAG_TAG,DATA_DIR,LOGS_DIR,GITPLAG_DIR,DEPLOY_DIR,GITHUB_SHA,GITHUB_REF
           script: |
             cd $DEPLOY_DIR
 
             docker-compose down
 
+            mkdir -p "$DATA_DIR"
+            mkdir -p "$LOGS_DIR"
+            mkdir -p "$GITPLAG_DIR"
+            mkdir -p "$DEPLOY_DIR"
+
             cat > .env << EOL
-            REST_URL=$REST_URL
-            GITHUB_ID=$GITHUB_ID
-            GITHUB_SECRET=$GITHUB_SECRET
-            MOSS_USER_ID=$MOSS_USER_ID
-            POSTGRES_USER=$POSTGRES_USER
-            POSTGRES_PASSWORD=$POSTGRES_PASSWORD
-            POSTGRES_DB=$POSTGRES_DB
-            tag=${GITHUB_REF#refs/tags/}
-            data_dir=$DATA_DIR
-            logs_dir=$LOGS_DIR
-            data2graph_tag=$DATA2GRAPH_TAG
-            gitplag_tag=$GITPLAG_TAG
-            gitplag_dir=$GITPLAG_DIR
+            DEPLOYMENT_URL="$DEPLOYMENT_URL"
+            REST_URL="$REST_URL"
+            GITHUB_ID="$GITHUB_ID"
+            GITHUB_SECRET="$GITHUB_SECRET"
+            GITPLAG_GITHUB_AUTH="$GITPLAG_GITHUB_AUTH"
+            MOSS_USER_ID="$MOSS_USER_ID"
+            POSTGRES_USER="$POSTGRES_USER"
+            POSTGRES_PASSWORD="$POSTGRES_PASSWORD"
+            POSTGRES_DB="$POSTGRES_DB"
+            GITPLAG_POSTGRES_DB="$GITPLAG_POSTGRES_DB"
+            tag="${GITHUB_REF#refs/tags/}"
+            data_dir="$DATA_DIR"
+            logs_dir="$LOGS_DIR"
+            data2graph_tag="$DATA2GRAPH_TAG"
+            gitplag_tag="$GITPLAG_TAG"
+            gitplag_dir="$GITPLAG_DIR"
             EOL
 
+            mkdir -p postgres
             wget "https://raw.githubusercontent.com/tcibinan/flaxo/$GITHUB_SHA/docker/compose/docker-compose.yml" \
                  -O docker-compose.yml
+            wget "https://raw.githubusercontent.com/tcibinan/flaxo/$GITHUB_SHA/docker/compose/postgres/init.sh" \
+                 -O postgres/init.sh
+
             docker-compose up -d

--- a/.github/workflows/release-deployment-workflow.yml
+++ b/.github/workflows/release-deployment-workflow.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Deploy flaxo
         uses: appleboy/ssh-action@v0.0.5
         env:
+          DEPLOYMENT_URL: http://${{ secrets.DEV_HOST }}
           REST_URL: http://${{ secrets.DEV_HOST }}:${{ secrets.DEV_PORT }}/rest
           GITHUB_ID: ${{ secrets.GITHUB_ID }}
           GITHUB_SECRET: ${{ secrets.GITHUB_SECRET }}
@@ -77,13 +78,15 @@ jobs:
           DATA_DIR: /root/flaxo-automation/db
           LOGS_DIR: /root/flaxo-automation/logs
           DATA2GRAPH_TAG: 0.4
+          GITPLAG_TAG: 0.5.2
+          GITPLAG_DIR: /root/flaxo-automation/gitplag
           DEPLOY_DIR: /root/flaxo-automation/deploy
         with:
           host: ${{ secrets.DEV_HOST }}
           port: ${{ secrets.DEV_PORT }}
           username: ${{ secrets.DEV_USERNAME }}
           password: ${{ secrets.DEV_PASSWORD }}
-          envs: REST_URL,GITHUB_ID,GITHUB_SECRET,MOSS_USER_ID,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,DATA_DIR,LOGS_DIR,DATA2GRAPH_TAG,DEPLOY_DIR,GITHUB_SHA,GITHUB_REF
+          envs: REST_URL,GITHUB_ID,GITHUB_SECRET,MOSS_USER_ID,POSTGRES_USER,POSTGRES_PASSWORD,POSTGRES_DB,DATA_DIR,LOGS_DIR,DATA2GRAPH_TAG,GITPLAG_TAG,GITPLAG_DIR,DEPLOY_DIR,GITHUB_SHA,GITHUB_REF
           script: |
             cd $DEPLOY_DIR
 
@@ -101,6 +104,8 @@ jobs:
             data_dir=$DATA_DIR
             logs_dir=$LOGS_DIR
             data2graph_tag=$DATA2GRAPH_TAG
+            gitplag_tag=$GITPLAG_TAG
+            gitplag_dir=$GITPLAG_DIR
             EOL
 
             wget "https://raw.githubusercontent.com/tcibinan/flaxo/$GITHUB_SHA/docker/compose/docker-compose.yml" \

--- a/.github/workflows/release-deployment-workflow.yml
+++ b/.github/workflows/release-deployment-workflow.yml
@@ -52,15 +52,18 @@ jobs:
     steps:
       - name: Dump database
         uses: appleboy/ssh-action@v0.0.5
+        env:
+          DUMPS_DIR: /root/flaxo-automation/dumps
         with:
           host: ${{ secrets.DEV_HOST }}
           port: ${{ secrets.DEV_PORT }}
           username: ${{ secrets.DEV_USERNAME }}
           password: ${{ secrets.DEV_PASSWORD }}
+          envs: DUMPS_DIR
           script: |
             CURRENT_DATE=$(date +%Y-%m-%d.%H:%M:%S)
-            docker exec flaxo-db pg_dump -U ${{ secrets.POSTGRES_USER }} ${{ secrets.POSTGRES_DB }} > "/root/flaxo-automation/dumps/flaxo.$CURRENT_DATE.bak"
-            docker exec flaxo-db pg_dump -U ${{ secrets.POSTGRES_USER }} ${{ secrets.GITPLAG_POSTGRES_DB }} > "/root/flaxo-automation/dumps/gitplag.$CURRENT_DATE.bak"
+            docker exec flaxo-db pg_dump -U ${{ secrets.POSTGRES_USER }} ${{ secrets.POSTGRES_DB }} > "$DUMPS_DIR/flaxo.$CURRENT_DATE.bak"
+            docker exec flaxo-db pg_dump -U ${{ secrets.POSTGRES_USER }} ${{ secrets.GITPLAG_POSTGRES_DB }} > "$DUMPS_DIR/gitplag.$CURRENT_DATE.bak"
   deploy:
     name: Deploy flaxo to dev server
     runs-on: ubuntu-latest

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -20,8 +20,8 @@ services:
       POSTGRES_DB:
       GITPLAG_URL: "http://gitplag:8090"
       GITPLAG_UI_URL: "${DEPLOYMENT_URL}:8880"
-      PLAGIARISM_ANALYSER: gitplag
-      postgres_host: postgres
+      PLAGIARISM_ANALYSER: "gitplag"
+      postgres_host: "postgres"
   frontend:
     image: flaxo/frontend:${tag}
     container_name: flaxo-frontend
@@ -39,7 +39,7 @@ services:
     environment:
       POSTGRES_USER:
       POSTGRES_PASSWORD:
-      POSTGRES_DBS: ${POSTGRES_DB},${GITPLAG_POSTGRES_DB}
+      POSTGRES_DBS: "${POSTGRES_DB},${GITPLAG_POSTGRES_DB}"
   data2graph:
     image: flaxo/data2graph:${data2graph_tag}
     container_name: flaxo-data2graph
@@ -62,10 +62,10 @@ services:
     volumes:
       - ${gitplag_dir}:/mnt/gitplag
     environment:
-      GITPLAG_MOSS_ID: ${MOSS_USER_ID}
-      GITPLAG_DATASOURCE_URL: jdbc:postgresql://postgres:5432/${GITPLAG_POSTGRES_DB}
-      GITPLAG_DATASOURCE_USERNAME: ${POSTGRES_USER}
-      GITPLAG_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
-      GITPLAG_SERVER_URL: ${DEPLOYMENT_URL}:8090
-      GITPLAG_UI_URL: ${DEPLOYMENT_URL}:8880
+      GITPLAG_MOSS_ID: "${MOSS_USER_ID}"
+      GITPLAG_DATASOURCE_URL: "jdbc:postgresql://postgres:5432/${GITPLAG_POSTGRES_DB}"
+      GITPLAG_DATASOURCE_USERNAME: "${POSTGRES_USER}"
+      GITPLAG_DATASOURCE_PASSWORD: "${POSTGRES_PASSWORD}"
+      GITPLAG_SERVER_URL: "${DEPLOYMENT_URL}:8090"
+      GITPLAG_UI_URL: "${DEPLOYMENT_URL}:8880"
       GITPLAG_GITHUB_AUTH:

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -35,3 +35,23 @@ services:
     container_name: flaxo-data2graph
     ports:
       - 8088:80
+  gitplag-ui:
+    image: nikstep/gitplag-ui:${gitplag_tag}
+    container_name: flaxo-gitplag-ui
+    ports:
+      - 8880:80
+  gitplag:
+    image: nikstep/gitplag:${gitplag_tag}
+    container_name: flaxo-gitplag
+    ports:
+      - 8090:8090
+    volumes:
+      - ${gitplag_dir}:/mnt/gitplag
+    environment:
+      GITPLAG_MOSS_ID: ${MOSS_USER_ID}
+      GITPLAG_DATASOURCE_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB}
+      GITPLAG_DATASOURCE_USERNAME: ${POSTGRES_USER}
+      GITPLAG_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
+      GITPLAG_SERVER_URL: ${DEPLOYMENT_URL}:8090
+      GITPLAG_UI_URL: ${DEPLOYMENT_URL}:8880
+      GITPLAG_GITHUB_AUTH:

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -3,6 +3,9 @@ services:
   backend:
     image: flaxo/backend:${tag}
     container_name: flaxo-backend
+    depends_on:
+      - postgres
+      - gitplag
     ports:
       - 8080:8080
     volumes:
@@ -15,10 +18,16 @@ services:
       POSTGRES_USER:
       POSTGRES_PASSWORD:
       POSTGRES_DB:
+      GITPLAG_URL: "http://gitplag:8090"
+      GITPLAG_UI_URL: "${DEPLOYMENT_URL}:8880"
+      PLAGIARISM_ANALYSER: gitplag
       postgres_host: postgres
   frontend:
     image: flaxo/frontend:${tag}
     container_name: flaxo-frontend
+    depends_on:
+      - backend
+      - data2graph
     ports:
       - 80:80
   postgres:
@@ -26,10 +35,11 @@ services:
     container_name: flaxo-db
     volumes:
       - ${data_dir}:/var/lib/postgresql/data
+      - ./postgres:/docker-entrypoint-initdb.d
     environment:
       POSTGRES_USER:
       POSTGRES_PASSWORD:
-      POSTGRES_DB:
+      POSTGRES_DBS: ${POSTGRES_DB},${GITPLAG_POSTGRES_DB}
   data2graph:
     image: flaxo/data2graph:${data2graph_tag}
     container_name: flaxo-data2graph
@@ -38,18 +48,22 @@ services:
   gitplag-ui:
     image: nikstep/gitplag-ui:${gitplag_tag}
     container_name: flaxo-gitplag-ui
+    depends_on:
+      - gitplag
     ports:
       - 8880:80
   gitplag:
     image: nikstep/gitplag:${gitplag_tag}
     container_name: flaxo-gitplag
+    depends_on:
+      - postgres
     ports:
       - 8090:8090
     volumes:
       - ${gitplag_dir}:/mnt/gitplag
     environment:
       GITPLAG_MOSS_ID: ${MOSS_USER_ID}
-      GITPLAG_DATASOURCE_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB}
+      GITPLAG_DATASOURCE_URL: jdbc:postgresql://postgres:5432/${GITPLAG_POSTGRES_DB}
       GITPLAG_DATASOURCE_USERNAME: ${POSTGRES_USER}
       GITPLAG_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       GITPLAG_SERVER_URL: ${DEPLOYMENT_URL}:8090

--- a/docker/compose/postgres/init.sh
+++ b/docker/compose/postgres/init.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -eu
+
+if [[ "$POSTGRES_DBS" ]]; then
+	for DB in $(echo $POSTGRES_DBS | tr ',' ' '); do
+    psql -U "$POSTGRES_USER" <<-EOSQL
+      CREATE DATABASE $DB;
+EOSQL
+	done
+fi

--- a/docs/getting-started/deploy.md
+++ b/docs/getting-started/deploy.md
@@ -42,15 +42,19 @@ Once a GitHub OAuth App is created and MOSS `userid` is retrieved then you can r
 |----------|-------------|
 | GITHUB_ID | Created GitHub OAuth app `id`. |
 | GITHUB_SECRET | Created GitHub OAuth app `secret`. |
+| GITPLAG_GITHUB_AUTH | Default GitHub authentication token for gitplag. |
 | MOSS_USER_ID | Retrieved MOSS `userid`. |
+| DEPLOYMENT_URL | URL of the Flaxo deployment server or Homepage URL. The endpoint should be available from the outer network.  F.e. `http://8.8.8.8`. |
 | REST_URL | Rest endpoint of the Flaxo deployment. The endpoint should be available from the outer network.  F.e. `http://8.8.8.8:8080/rest`. |
 | POSTGRES_USER | User name to connect to the packaged PostgreSQL DB. |
 | POSTGRES_PASSWORD | User password to connect to the packaged PostgreSQL DB. |
 | POSTGRES_DB | Database name to use in the packaged PostgreSQL DB. |
 | tag | ![Flaxo latest pre-release](https://img.shields.io/github/release-pre/tcibinan/flaxo.svg?label=pre-release) <br> Flaxo release to use. Latest release can be found [here](https://github.com/tcibinan/flaxo/releases). |
-| data2graph_tag | ![Data2Graph latest pre-release](https://img.shields.io/github/release-pre/tcibinan/data2graph.svg?label=pre-release) <br> Data2graph release to use. It should be specified without `v` prefix, f.e. `v0.4` becomes `0.4`. Latest release can be found [here](https://github.com/tcibinan/data2graph/releases). | 
+| data2graph_tag | ![Data2Graph latest pre-release](https://img.shields.io/github/release-pre/tcibinan/data2graph.svg?label=pre-release) <br> Data2graph release to use. It should be specified without `v` prefix, f.e. `v0.4` becomes `0.4`. Latest release can be found [here](https://github.com/tcibinan/data2graph/releases). |
+| gitplag_tag | ![Gitplag latest pre-release](https://img.shields.io/github/release-pre/gitplag/gitplag.svg?label=pre-release) <br> GitPlag release to use. It should be specified without `v` prefix, f.e. `v0.5.2` becomes `0.5.2`. Latest release can be found [here](https://github.com/gitplag/gitplag/releases).
 | data_dir | Host local directory to store packaged PostgreSQL DB files. |
 | logs_dir | Host local directory to store backend logs. |
+| gitplag_dir | Host local directory to store gitplag localized files. |
 
 ## Launch
 
@@ -70,7 +74,7 @@ Checkout to the required Flaxo release.
 Latest release can be found [here](https://github.com/tcibinan/flaxo/releases).
 
 ```bash
-git checkout v0.3
+git checkout 0.7
 ```
 
 Change current directory to the docker compose directory.
@@ -85,15 +89,19 @@ Create `.env` file and fill it with the previously resolved deployment parameter
 cat > .env << EOL
 GITHUB_ID=123456
 GITHUB_SECRET=secretalphanumericstring12345
+GITPLAG_GITHUB_AUTH=anothersecretalphanumericstring12345
 MOSS_USER_ID=123456
+DEPLOYMENT_URL=http://8.8.8.8
 REST_URL=http://8.8.8.8:8080/rest
 POSTGRES_USER=flaxo
 POSTGRES_PASSWORD=tobechanged
 POSTGRES_DB=flaxo
-tag=0.3
+tag=0.7
 data2graph_tag=0.4
+gitplag_tag=0.5.2
 data_dir=/local/path/to/db/files
 logs_dir=/local/path/to/log/files
+gitplag_dir=/local/path/to/gitplag/files
 EOL
 ```
 

--- a/docs/getting-started/deploy.md
+++ b/docs/getting-started/deploy.md
@@ -48,7 +48,8 @@ Once a GitHub OAuth App is created and MOSS `userid` is retrieved then you can r
 | REST_URL | Rest endpoint of the Flaxo deployment. The endpoint should be available from the outer network.  F.e. `http://8.8.8.8:8080/rest`. |
 | POSTGRES_USER | User name to connect to the packaged PostgreSQL DB. |
 | POSTGRES_PASSWORD | User password to connect to the packaged PostgreSQL DB. |
-| POSTGRES_DB | Database name to use in the packaged PostgreSQL DB. |
+| POSTGRES_DB | Database name to use by flaxo in the packaged PostgreSQL DB. |
+| GITPLAG_POSTGRES_DB | Database name to use by gitplag in the packaged PostgreSQL DB. |
 | tag | ![Flaxo latest pre-release](https://img.shields.io/github/release-pre/tcibinan/flaxo.svg?label=pre-release) <br> Flaxo release to use. Latest release can be found [here](https://github.com/tcibinan/flaxo/releases). |
 | data2graph_tag | ![Data2Graph latest pre-release](https://img.shields.io/github/release-pre/tcibinan/data2graph.svg?label=pre-release) <br> Data2graph release to use. It should be specified without `v` prefix, f.e. `v0.4` becomes `0.4`. Latest release can be found [here](https://github.com/tcibinan/data2graph/releases). |
 | gitplag_tag | ![Gitplag latest pre-release](https://img.shields.io/github/release-pre/gitplag/gitplag.svg?label=pre-release) <br> GitPlag release to use. It should be specified without `v` prefix, f.e. `v0.5.2` becomes `0.5.2`. Latest release can be found [here](https://github.com/gitplag/gitplag/releases).
@@ -96,6 +97,7 @@ REST_URL=http://8.8.8.8:8080/rest
 POSTGRES_USER=flaxo
 POSTGRES_PASSWORD=tobechanged
 POSTGRES_DB=flaxo
+GITPLAG_POSTGRES_DB=gitplag
 tag=0.7
 data2graph_tag=0.4
 gitplag_tag=0.5.2

--- a/rest/src/main/resources/flaxo.properties
+++ b/rest/src/main/resources/flaxo.properties
@@ -1,6 +1,6 @@
-flaxo.github.hook.url=${REST_URL}/github/hook
-flaxo.travis.hook.url=${REST_URL}/travis/hook
+flaxo.github.hook.url=${REST_URL:http://localhost:8080/rest}/github/hook
+flaxo.travis.hook.url=${REST_URL:http://localhost:8080/rest}/travis/hook
 flaxo.plagiarism.analyser=${PLAGIARISM_ANALYSER:moss}
-flaxo.gitplag.url=${GITPLAG_URL}
-flaxo.gitplag.ui.url=${GITPLAG_UI_URL}
+flaxo.gitplag.url=${GITPLAG_URL:http://localhost:8090}
+flaxo.gitplag.ui.url=${GITPLAG_UI_URL:http://localhost:8880}
 flaxo.gitplag.timeout.seconds=300


### PR DESCRIPTION
Resolves #63.

The pull request updates current flaxo deployment configuration to make gitplag containers deploy as well. Both flaxo and gitplag uses the same postgres container and only the databases of the services differs.